### PR TITLE
use sloc v0.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ npm-debug.log
 node_modules/
 output/
 .idea/
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.9"
   - "0.10"
 after_script:
   - npm run coveralls

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var gutil = require('gulp-util');
 var sloc = require('sloc');
 
 function gulpSloc(options) {
-  var supportedExtensions = ['js', 'cc', 'c', 'coffeescript', 'coffee', 'python', 'py', 'java', 'php'];
+  var supportedExtensions = sloc.extensions;
   var log = gutil.log;
   var colors = gutil.colors;
   var File = gutil.File;
@@ -24,7 +24,7 @@ function gulpSloc(options) {
 
   return (function () {
 
-    var counters = { loc: 0, sloc: 0, cloc: 0, scloc: 0, mcloc: 0, nloc: 0, file: 0 };
+    var counters = { total: 0, source: 0, comment: 0, single: 0, block: 0, empty: 0, file: 0 };
 
     function writeJsonReport() {
       /*jshint validthis: true*/
@@ -54,7 +54,7 @@ function gulpSloc(options) {
 
       var stats = sloc(source, ext);
 
-      // iterates through loc, sloc, cloc, scloc, mcloc, nloc
+      // iterates through total, source, comment, single, block, empty
       Object.getOwnPropertyNames(stats).forEach(function (key) {
         counters[key] += stats[key];
       });
@@ -66,12 +66,12 @@ function gulpSloc(options) {
       /*jshint validthis: true*/
 
       log('-------------------------------');
-      log('        physical lines : ' + colors.green(String(counters.loc)));
-      log('  lines of source code : ' + colors.green(String(counters.sloc)));
-      log('         total comment : ' + colors.cyan(String(counters.cloc)));
-      log('            singleline : ' + String(counters.scloc));
-      log('             multiline : ' + String(counters.mcloc));
-      log('                 empty : ' + colors.red(String(counters.nloc)));
+      log('        physical lines : ' + colors.green(String(counters.total)));
+      log('  lines of source code : ' + colors.green(String(counters.source)));
+      log('         total comment : ' + colors.cyan(String(counters.comment)));
+      log('            singleline : ' + String(counters.single));
+      log('             multiline : ' + String(counters.block));
+      log('                 empty : ' + colors.red(String(counters.empty)));
       log('');
       log('  number of files read : ' + colors.green(String(counters.file)));
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "mkdirp": "^0.4.0",
     "lodash": "^2.4.1",
-    "sloc": "0.1.0",
+    "sloc": "0.1.1",
     "event-stream": "^3.1.2",
     "gulp-util": "^2.2.14"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "mkdirp": "^0.4.0",
     "lodash": "^2.4.1",
-    "sloc": "0.0.7",
+    "sloc": "0.1.0",
     "event-stream": "^3.1.2",
     "gulp-util": "^2.2.14"
   },


### PR DESCRIPTION
There are breaking changes with `v0.1.0`. Here is a patch that should work with it.
Moreover: What do you think about extending the [sloc `simple` formatter](https://github.com/flosse/sloc/blob/master/src/formatters/simple.coffee) to reuse some code?
